### PR TITLE
Don't call createNewProps if component unmounted within event handler

### DIFF
--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -93,6 +93,14 @@ module.exports = function connectBackboneToReact(
       }
 
       createNewProps() {
+        // Bail out if our component has been unmounted.
+        // The only case where this flag is encountered is when this component
+        // is unmounted within an event handler but the 'all' event is still triggered.
+        // It is covered in a test case.
+        if (this.hasBeenUnmounted) {
+          return;
+        }
+
         this.setState(mapModelsToProps(this.models));
       }
 
@@ -108,6 +116,8 @@ module.exports = function connectBackboneToReact(
             model.off(name, this.createNewProps, this);
           });
         });
+
+        this.hasBeenUnmounted = true;
       }
 
       render() {

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -62,7 +62,7 @@ module.exports = function connectBackboneToReact(
 
     const displayName = getDisplayName(wrappedComponentName);
 
-    class Connect extends Component {
+    class ConnectBackboneToReact extends Component {
       constructor(props, context) {
         super(props, context);
 
@@ -128,11 +128,11 @@ module.exports = function connectBackboneToReact(
       models: PropTypes.object,
     };
 
-    Connect.WrappedComponent = WrappedComponent;
-    Connect.displayName = displayName;
-    Connect.propTypes = propTypes;
-    Connect.contextTypes = propTypes;
+    ConnectBackboneToReact.WrappedComponent = WrappedComponent;
+    ConnectBackboneToReact.displayName = displayName;
+    ConnectBackboneToReact.propTypes = propTypes;
+    ConnectBackboneToReact.contextTypes = propTypes;
 
-    return hoistStatics(Connect, WrappedComponent);
+    return hoistStatics(ConnectBackboneToReact, WrappedComponent);
   };
 };

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -86,16 +86,13 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when mounted', function() {
-    let renderSpy;
+    let setStateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
-      renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
-
-      // Don't track initial render.
-      renderSpy.reset();
     });
 
     afterEach(function() {
@@ -122,7 +119,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(stub.props().name, newName);
 
-      assert.equal(renderSpy.callCount, 4);
+      assert.equal(setStateSpy.callCount, 4);
     });
 
     it('updates properties when model and collections change', function() {
@@ -132,7 +129,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(stub.props().name, newName);
 
-      assert.equal(renderSpy.callCount, 4);
+      assert.equal(setStateSpy.callCount, 4);
     });
 
     it('creates listeners for every model', function() {
@@ -159,19 +156,16 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when mounted with debounce set to true', function() {
-    let renderSpy;
+    let setStateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
         { debounce: true }
       )(TestComponent);
-      renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
-
-      // Don't track initial render.
-      renderSpy.reset();
     });
 
     afterEach(function() {
@@ -187,7 +181,7 @@ describe('connectBackboneToReact', function() {
         assert.equal(userModel.get('name'), newName);
         assert.equal(stub.props().name, newName);
 
-        assert.equal(renderSpy.callCount, 1);
+        assert.equal(setStateSpy.callCount, 1);
 
         done();
       }, 0);
@@ -202,12 +196,12 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(stub.props().name, 'Harry');
 
-      assert.equal(renderSpy.callCount, 0);
+      assert.equal(setStateSpy.callCount, 0);
     });
   });
 
   describe('when mounted with custom event names', function() {
-    let renderSpy;
+    let setStateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
@@ -218,13 +212,10 @@ describe('connectBackboneToReact', function() {
           },
         }
       )(TestComponent);
-      renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
-
-      // Don't track initial render.
-      renderSpy.reset();
     });
 
     afterEach(function() {
@@ -251,7 +242,7 @@ describe('connectBackboneToReact', function() {
     it('rerenders when tracked property changes', function() {
       const newName = 'Banana';
       userModel.set('name', newName);
-      assert.equal(renderSpy.callCount, 1);
+      assert.equal(setStateSpy.callCount, 1);
     });
 
     it('does not update properties when non tracked property changes', function() {
@@ -261,13 +252,13 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('age'), newAge);
       assert.equal(stub.props().age, 25);
 
-      assert.equal(renderSpy.callCount, 0);
+      assert.equal(setStateSpy.callCount, 0);
     });
 
     it('does not rerender when non tracked property changes', function() {
       const newAge = 99;
       userModel.set('age', newAge);
-      assert.equal(renderSpy.callCount, 0);
+      assert.equal(setStateSpy.callCount, 0);
     });
   });
 
@@ -328,16 +319,13 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when only given modelsMap object', function() {
-    let renderSpy;
+    let setStateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact()(TestComponent);
-      renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
-
-      // Don't track initial render.
-      renderSpy.reset();
     });
 
     afterEach(function() {
@@ -364,12 +352,12 @@ describe('connectBackboneToReact', function() {
 
       assert.equal(stub.props().user.name, 'Banana');
 
-      assert.equal(renderSpy.callCount, 4);
+      assert.equal(setStateSpy.callCount, 4);
     });
   });
 
   describe('when given modelsMap and event options', function() {
-    let renderSpy;
+    let setStateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         null,
@@ -380,13 +368,10 @@ describe('connectBackboneToReact', function() {
           },
         }
       )(TestComponent);
-      renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
-
-      // Don't track initial render.
-      renderSpy.reset();
     });
 
     afterEach(function() {
@@ -414,13 +399,13 @@ describe('connectBackboneToReact', function() {
 
       assert.equal(stub.props().user.name, 'Banana');
 
-      assert.equal(renderSpy.callCount, 1);
+      assert.equal(setStateSpy.callCount, 1);
     });
   });
 
   describe('when modelTypes are defined on the options object', function() {
     describe('and the model given is not an instance of required modelType', function() {
-      let renderSpy;
+      let setStateSpy;
       let errObj;
 
       beforeEach(function() {
@@ -432,7 +417,7 @@ describe('connectBackboneToReact', function() {
             },
           }
         )(TestComponent);
-        renderSpy = sandbox.spy(ConnectedTest.prototype, 'render');
+        setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
         settingsModel = new SettingsModel();
         modelsMap = {
@@ -447,7 +432,7 @@ describe('connectBackboneToReact', function() {
       });
 
       it('does not render', function() {
-        assert.equal(renderSpy.callCount, 0);
+        assert.equal(setStateSpy.callCount, 0);
       });
 
       it('throws an error', function() {
@@ -510,7 +495,7 @@ describe('connectBackboneToReact', function() {
 
       // Subscribe to an arbitrary event.
       userModel.on(arbitraryEvent, function() {
-        // When called it unmounts are component.
+        // When called it unmounts an component.
         wrapper.unmount();
 
         // But because we're subscribed to the "all" event it will still trigger that handler,
@@ -519,10 +504,6 @@ describe('connectBackboneToReact', function() {
 
       // Trigger the event.
       userModel.trigger(arbitraryEvent);
-    });
-
-    afterEach(function() {
-      wrapper.unmount();
     });
 
     it('does not call setState', function() {


### PR DESCRIPTION
"all" event handlers are triggered after individual event handlers.
That is to say, if you trigger "foo" the sequence of event handlers called is:
"foo" -> all event handlers (which can include additional triggers) -> "all" -> event handlers.
When you .off('all') within an event handler Backbone reassigns the "all" array of handlers
such that when you get to triggering the "all" event handlers that array has not been updated.
This is the line that reassigns that array: https://github.com/jashkenas/backbone/blob/bd50e2e4a4af5c09bc490185aab215794d42258b/backbone.js#L296
So that when you get here https://github.com/jashkenas/backbone/blob/bd50e2e4a4af5c09bc490185aab215794d42258b/backbone.js#L357
the "allEvents" value is stale.