### PR TITLE
Fix models existence check on componentWillReceiveProps

### DIFF
--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -119,7 +119,7 @@ module.exports = function connectBackboneToReact(
         // Bind event listeners for each model that changed.
         Object.keys(this.models).forEach(mapKey => {
           const model = this.models[mapKey];
-          if (this.props.models[mapKey] === this.models[mapKey] ||
+          if ((this.props.models && this.props.models[mapKey] === this.models[mapKey]) ||
             (this.context.models && this.context.models[mapKey] === this.models[mapKey])) {
             return; // Did not change.
           }

--- a/test/backbone-provider.test.js
+++ b/test/backbone-provider.test.js
@@ -98,5 +98,12 @@ describe('BackboneProvider', function() {
         wrapper.find('.name').everyWhere(n => n.text() === 'Harry')
       );
     });
+
+    it('should handle updates to passed props', function() {
+      const model = new Model({ name: 'Jill' });
+      wrapper.setProps({ models: { user: model }});
+
+      wrapper.find('.name').everyWhere(n => n.text() === 'Jill');
+    });
   });
 });


### PR DESCRIPTION
Without this check, `componentWillReceive`, when used in conjunction with `BackboneProvider` fails with a type error if the child component is nested and does not have a models prop.

Example:
For this component setup,
```jsx
<BackboneProvider models={{foo}}>
  <Parent>
    <EmptyChild>
      <Child />
    </EmptyChild>
  </Parent>
</BackboneProvider>
```
If we run
```js
function mapModelsToProps(models) {
  return { foo: models.foo };
}
connectBackboneToReact(mapModelsToProps, { 
  events: { 'foo': 'changed:property' }
})(Child);
```
And update `foo`, we trigger the type error.
 