### PR TITLE
Fixes error when passed an undefined model

### DIFF
--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -90,6 +90,9 @@ module.exports = function connectBackboneToReact(
       createEventListeners() {
         Object.keys(this.models).forEach(mapKey => {
           const model = this.models[mapKey];
+          // Do not attempt to create event listeners on an undefined model.
+          if (!model) return;
+
           this.createEventListener(mapKey, model);
         });
       }
@@ -135,6 +138,8 @@ module.exports = function connectBackboneToReact(
 
         Object.keys(this.models).forEach(mapKey => {
           const model = this.models[mapKey];
+          // Do not attempt to remove event listeners on an undefined model.
+          if (!model) return;
 
           getEventNames(mapKey).forEach(name => {
             model.off(name, this.createNewProps, this);

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -10,6 +10,8 @@ function getDisplayName(name) {
 function defaultMapModelsToProps(models) {
   return Object.keys(models).reduce((acc, modelKey) => {
     const model = models[modelKey];
+    if (!model) return;
+
     acc[modelKey] = model.toJSON();
     return acc;
   }, {});

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -200,6 +200,24 @@ describe('connectBackboneToReact', function() {
     });
   });
 
+  describe('when mounted with an undefined model', function() {
+    afterEach(function() {
+      wrapper.unmount();
+    });
+
+    function mapEmptyModel({ user }) {
+      return { user };
+    }
+
+    it('should mount and unmount the component successfully', function() {
+      const ConnectedTest = connectBackboneToReact(mapEmptyModel)(TestComponent);
+      const setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      wrapper = mount(<ConnectedTest models={{ user: null }} />);
+      assert(wrapper.find('.name'));
+      assert.equal(setStateSpy.callCount, 0);
+    });
+  });
+
   describe('when mounted with custom event names', function() {
     let setStateSpy;
     beforeEach(function() {

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -205,16 +205,11 @@ describe('connectBackboneToReact', function() {
       wrapper.unmount();
     });
 
-    function mapEmptyModel({ user }) {
-      return { user };
-    }
-
-    it('should mount and unmount the component successfully', function() {
-      const ConnectedTest = connectBackboneToReact(mapEmptyModel)(TestComponent);
-      const setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
-      wrapper = mount(<ConnectedTest models={{ user: null }} />);
-      assert(wrapper.find('.name'));
-      assert.equal(setStateSpy.callCount, 0);
+    it('the default should mount and unmount the component successfully', function() {
+      const ConnectedTest = connectBackboneToReact()(TestComponent);
+      const eventListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
+      wrapper = mount(<ConnectedTest models={{user: null}} />);
+      assert.equal(eventListenerSpy.callCount, 0);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mongodb-js/connect-backbone-to-react/issues/8

I added a safety check when mounting or unmounting components for undefined models. Since there's nothing we can do to a null model, we should not attempt to add event listeners. If the model is actually required, prop types should validate it, not a type error.