### PR TITLE
Feature: Add props as second arg to mapModelsToProps

### DIFF
--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -71,7 +71,7 @@ module.exports = function connectBackboneToReact(
 
         this.setModels(props, context);
 
-        this.state = mapModelsToProps(this.models);
+        this.state = mapModelsToProps(this.models, this.props);
 
         this.createNewProps = this.createNewProps.bind(this);
 
@@ -114,7 +114,7 @@ module.exports = function connectBackboneToReact(
           return;
         }
 
-        this.setState(mapModelsToProps(this.models));
+        this.setState(mapModelsToProps(this.models, this.props));
       }
 
       componentWillReceiveProps(nextProps, nextContext) {


### PR DESCRIPTION
Implements https://github.com/mongodb-js/connect-backbone-to-react/issues/9

This is a nice feature for deriving which models to map into your state
based on existing props. It can be especially useful for retrieving a
model from a collection based on a value (as in the tests).

Just a two-line change in the main file for lots of increased
functionality.