### PR TITLE
feat: Add access to wrapped component's ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ const options = {
     user: UserModel,
     allUsers: UserCollection,
   },
+
+  // Enable access to the wrapped component's ref with the `withRef` option.
+  // You can then access the wrapped component from the connected component's `getWrappedInstance()`.
+  // This is similar to react-redux's connectAdvanced() HOC.
+  // By default, `withRef` is false.
+  withRef: true,
 };
 
 const { connectBackboneToReact } = require('connect-backbone-to-react');

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -29,6 +29,7 @@ module.exports = function connectBackboneToReact(
     debounce = false,
     events = {},
     modelTypes = {},
+    withRef = false,
   } = options;
 
   function getEventNames(modelName) {
@@ -74,6 +75,7 @@ module.exports = function connectBackboneToReact(
         this.state = mapModelsToProps(this.models, this.props);
 
         this.createNewProps = this.createNewProps.bind(this);
+        this.setWrappedInstance = this.setWrappedInstance.bind(this);
 
         if (debounce) {
           const debounceWait = typeof debounce === 'number' ? debounce : 0;
@@ -115,6 +117,18 @@ module.exports = function connectBackboneToReact(
         }
 
         this.setState(mapModelsToProps(this.models, this.props));
+      }
+
+      setWrappedInstance(ref) {
+        this.wrappedInstance = ref;
+      }
+
+      getWrappedInstance() {
+        if (!withRef) {
+          throw new Error('getWrappedInstance() requires withRef to be true.');
+        }
+
+        return this.wrappedInstance;
       }
 
       componentWillReceiveProps(nextProps, nextContext) {
@@ -160,6 +174,10 @@ module.exports = function connectBackboneToReact(
 
         // Don't pass through models prop.
         wrappedProps.models = undefined;
+
+        if (withRef) {
+          wrappedProps.ref = this.setWrappedInstance;
+        }
 
         return createElement(WrappedComponent, wrappedProps);
       }

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -631,4 +631,68 @@ describe('connectBackboneToReact', function() {
       assert.equal(setStateSpy.called, false);
     });
   });
+
+  describe('when NOT configured to provide ref to the wrapped component', function() {
+    beforeEach(function() {
+      // eslint-disable-next-line no-unused-vars
+      const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
+
+      wrapper = mount(<ConnectedTest models={modelsMap} />);
+      stub = wrapper.find(TestComponent);
+    });
+
+    afterEach(function() {
+      wrapper.unmount();
+    });
+
+    it('should throw an error when getWrappedInstance() is called', function() {
+      assert.throws(function() {
+        wrapper.instance().getWrappedInstance();
+      });
+    });
+  });
+
+  describe('when configured to provide ref to the wrapped component', function() {
+    beforeEach(function() {
+      // eslint-disable-next-line no-unused-vars
+      const ConnectedTest = connectBackboneToReact(
+        mapModelsToProps,
+        { withRef: true }
+      )(TestComponent);
+
+      wrapper = mount(<ConnectedTest models={modelsMap} />);
+      stub = wrapper.find(TestComponent);
+    });
+
+    afterEach(function() {
+      wrapper.unmount();
+    });
+
+    it('should return the wrapped component via getWrappedInstance()', function() {
+      assert.equal(wrapper.instance().getWrappedInstance(), stub.node);
+    });
+
+    describe('and the returned wrapped component', function() {
+      let randomName;
+
+      beforeEach(function() {
+        randomName = Math.random().toString();
+      });
+
+      it('should be able to update the actual component', function() {
+        wrapper.instance().getWrappedInstance().props.changeName(randomName);
+        assert.equal(stub.node.props.name, randomName);
+      });
+
+      it('should reflect the changes made to the actual component', function() {
+        stub.node.props.changeName(randomName);
+        assert.equal(wrapper.instance().getWrappedInstance().props.name, randomName);
+      });
+
+      it('should reflect the changes made to the data model', function() {
+        userModel.set('name', randomName);
+        assert.equal(wrapper.instance().getWrappedInstance().props.name, randomName);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Implements #18.

This PR is inspired by mixmaxhq#2, but I chose to follow react-redux's connectAdvanced() HOC's naming of `getWrappedInstance` as a reference. I also took a slightly different approach in the tests.