### PR TITLE
fix: adds check for null model to componentWillReceiveProps

### DIFF
--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -130,8 +130,8 @@ module.exports = function connectBackboneToReact(
         // Bind event listeners for each model that changed.
         Object.keys(this.models).forEach(mapKey => {
           const model = this.models[mapKey];
-          if ((this.props.models && this.props.models[mapKey] === this.models[mapKey]) ||
-            (this.context.models && this.context.models[mapKey] === this.models[mapKey])) {
+          if ((this.props.models && this.props.models[mapKey] === model) ||
+            (this.context.models && this.context.models[mapKey] === model)) {
             return; // Did not change.
           }
           // Do not attempt to create event listeners on an undefined model.

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -134,10 +134,17 @@ module.exports = function connectBackboneToReact(
             (this.context.models && this.context.models[mapKey] === model)) {
             return; // Did not change.
           }
+
           // Do not attempt to create event listeners on an undefined model.
           if (!model) {
             // Instead, if it was previously defined, remove the old listeners.
-            const prevModel = this.props.models[mapKey];
+            let prevModel;
+            if (this.props.models && this.props.models[mapKey]) {
+              prevModel = this.props.models[mapKey];
+            } else if (this.context.models && this.context.models[mapKey]) {
+              prevModel = this.context.models[mapKey];
+            }
+
             if (prevModel) this.removeEventListener(mapKey, prevModel);
             return;
           }

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -105,6 +105,12 @@ module.exports = function connectBackboneToReact(
         });
       }
 
+      removeEventListener(modelName, model) {
+        getEventNames(modelName).forEach(name => {
+          model.off(name, this.createNewProps, this);
+        });
+      }
+
       createNewProps() {
         // Bail out if our component has been unmounted.
         // The only case where this flag is encountered is when this component
@@ -132,12 +138,7 @@ module.exports = function connectBackboneToReact(
           if (!model) {
             // Instead, if it was previously defined, remove the old listeners.
             const prevModel = this.props.models[mapKey];
-            if (prevModel) {
-              getEventNames(mapKey).forEach(name => {
-                prevModel.off(name, this.createNewProps, this);
-              });
-            }
-
+            if (prevModel) this.removeEventListener(mapKey, prevModel);
             return;
           }
 
@@ -154,10 +155,7 @@ module.exports = function connectBackboneToReact(
           const model = this.models[mapKey];
           // Do not attempt to remove event listeners on an undefined model.
           if (!model) return;
-
-          getEventNames(mapKey).forEach(name => {
-            model.off(name, this.createNewProps, this);
-          });
+          this.removeEventListener(mapKey, model);
         });
 
         this.hasBeenUnmounted = true;

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -128,6 +128,8 @@ module.exports = function connectBackboneToReact(
             (this.context.models && this.context.models[mapKey] === this.models[mapKey])) {
             return; // Did not change.
           }
+          // Do not attempt to create event listeners on an undefined model.
+          if (!model) return;
 
           this.createEventListener(mapKey, model);
         });

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -129,7 +129,17 @@ module.exports = function connectBackboneToReact(
             return; // Did not change.
           }
           // Do not attempt to create event listeners on an undefined model.
-          if (!model) return;
+          if (!model) {
+            // Instead, if it was previously defined, remove the old listeners.
+            const prevModel = this.props.models[mapKey];
+            if (prevModel) {
+              getEventNames(mapKey).forEach(name => {
+                prevModel.off(name, this.createNewProps, this);
+              });
+            }
+
+            return;
+          }
 
           this.createEventListener(mapKey, model);
         });

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -130,24 +130,24 @@ module.exports = function connectBackboneToReact(
         // Bind event listeners for each model that changed.
         Object.keys(this.models).forEach(mapKey => {
           const model = this.models[mapKey];
-          if ((this.props.models && this.props.models[mapKey] === model) ||
-            (this.context.models && this.context.models[mapKey] === model)) {
-            return; // Did not change.
-          }
+
+          // Retrieve old versions of the model from props and context for comparison.
+          const propsModel = this.props.models ? this.props.models[mapKey] : undefined;
+          const contextModel = this.context.models ? this.context.models[mapKey] : undefined;
 
           // Do not attempt to create event listeners on an undefined model.
           if (!model) {
             // Instead, if it was previously defined, remove the old listeners.
-            let prevModel;
-            if (this.props.models && this.props.models[mapKey]) {
-              prevModel = this.props.models[mapKey];
-            } else if (this.context.models && this.context.models[mapKey]) {
-              prevModel = this.context.models[mapKey];
+            if (propsModel) {
+              this.removeEventListener(mapKey, propsModel);
+            } else if (contextModel) {
+              // this.setModel prefers props to context, so we do that here too.
+              this.removeEventListener(mapKey, contextModel);
             }
-
-            if (prevModel) this.removeEventListener(mapKey, prevModel);
             return;
           }
+
+          if ((propsModel === model) || (contextModel === model)) return; // Did not change.
 
           this.createEventListener(mapKey, model);
         });

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -140,8 +140,11 @@ module.exports = function connectBackboneToReact(
             // Instead, if it was previously defined, remove the old listeners.
             if (propsModel) {
               this.removeEventListener(mapKey, propsModel);
+              // If a model with the matching mapKey exists in both props and context,
+              // we only remove listeners from the one in props. We do this because
+              // only the one in props is actually used in this.models, per the
+              // Object.assign in setModel.
             } else if (contextModel) {
-              // this.setModel prefers props to context, so we do that here too.
               this.removeEventListener(mapKey, contextModel);
             }
             return;

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -594,15 +594,12 @@ describe('connectBackboneToReact', function() {
     });
   });
 
-  describe('when passed props change to include an undefined model', function() {
-    let setStateSpy;
-    let createListenerSpy;
-    let removeListenerSpy;
+  describe('when passed props change to include', function() {
+    let ConnectedTest;
 
     beforeEach(function() {
-      const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
+      ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
       wrapper = mount(<ConnectedTest models={modelsMap} />);
-      stub = wrapper.find(TestComponent);
 
       const decoratorUserModel = new UserModel({
         name: 'Robert',
@@ -617,34 +614,42 @@ describe('connectBackboneToReact', function() {
       };
 
       wrapper.setProps({ models: initialModelsMap });
-
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
-      createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
-      removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
-
-      const newModelsMap = {
-        user: userModel,
-        coll: userCollection,
-        decorator: undefined,
-      };
-
-      wrapper.setProps({ models: newModelsMap });
     });
 
     afterEach(function() {
       wrapper.unmount();
     });
 
-    it('calls setState once', function() {
-      assert.equal(setStateSpy.calledOnce, true);
-    });
+    describe('an undefined model', function() {
+      let setStateSpy;
+      let createListenerSpy;
+      let removeListenerSpy;
 
-    it('does not call createEventListener for the model', function() {
-      assert.equal(createListenerSpy.callCount, 0);
-    });
+      beforeEach(function() {
+        setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+        createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
+        removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
 
-    it('calls removeEventListener once for the model', function() {
-      assert.equal(removeListenerSpy.calledOnce, true);
+        const newModelsMap = {
+          user: userModel,
+          coll: userCollection,
+          decorator: undefined,
+        };
+
+        wrapper.setProps({ models: newModelsMap });
+      });
+
+      it('calls setState once', function() {
+        assert.equal(setStateSpy.calledOnce, true);
+      });
+
+      it('does not call createEventListener for the model', function() {
+        assert.equal(createListenerSpy.callCount, 0);
+      });
+
+      it('calls removeEventListener once for the model', function() {
+        assert.equal(removeListenerSpy.calledOnce, true);
+      });
     });
   });
 

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -594,6 +594,60 @@ describe('connectBackboneToReact', function() {
     });
   });
 
+  describe('when passed props change to include an undefined model', function() {
+    let setStateSpy;
+    let createListenerSpy;
+    let removeListenerSpy;
+
+    beforeEach(function() {
+      const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
+      wrapper = mount(<ConnectedTest models={modelsMap} />);
+      stub = wrapper.find(TestComponent);
+
+      const decoratorUserModel = new UserModel({
+        name: 'Robert',
+        age: '30',
+        hungry: false,
+      });
+
+      const initialModelsMap = {
+        user: userModel,
+        coll: userCollection,
+        decorator: decoratorUserModel,
+      };
+
+      wrapper.setProps({ models: initialModelsMap });
+
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
+      removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
+
+      const newModelsMap = {
+        user: userModel,
+        coll: userCollection,
+        decorator: undefined,
+      };
+
+      wrapper.setProps({ models: newModelsMap });
+    });
+
+    afterEach(function() {
+      wrapper.unmount();
+    });
+
+    it('calls setState once', function() {
+      assert.equal(setStateSpy.calledOnce, true);
+    });
+
+    it('does not call createEventListener for the model', function() {
+      assert.equal(createListenerSpy.callCount, 0);
+    });
+
+    it('calls removeEventListener once for the model', function() {
+      assert.equal(removeListenerSpy.calledOnce, true);
+    });
+  });
+
   describe('when unmounted in an event listener and subscribed to "all" event', function() {
     // To add more color, "all" event handlers are triggered after individual event handlers.
     // That is to say, if you trigger "foo" the sequence of event handlers called is:

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -596,10 +596,17 @@ describe('connectBackboneToReact', function() {
 
   describe('when passed props change to include', function() {
     let ConnectedTest;
+    let setStateSpy;
+    let createListenerSpy;
+    let removeListenerSpy;
 
     beforeEach(function() {
       ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
       wrapper = mount(<ConnectedTest models={modelsMap} />);
+
+      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
+      removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
 
       const decoratorUserModel = new UserModel({
         name: 'Robert',
@@ -620,16 +627,20 @@ describe('connectBackboneToReact', function() {
       wrapper.unmount();
     });
 
+    it('calls setState once', function() {
+      assert.equal(setStateSpy.callCount, 1);
+    });
+
+    it('calls createEventListener once for the model', function() {
+      assert.equal(createListenerSpy.callCount, 1);
+    });
+
+    it('does not call removeEventListener for the model', function() {
+      assert.equal(removeListenerSpy.callCount, 0);
+    });
+
     describe('an undefined model', function() {
-      let setStateSpy;
-      let createListenerSpy;
-      let removeListenerSpy;
-
       beforeEach(function() {
-        setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
-        createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
-        removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
-
         const newModelsMap = {
           user: userModel,
           coll: userCollection,
@@ -639,16 +650,16 @@ describe('connectBackboneToReact', function() {
         wrapper.setProps({ models: newModelsMap });
       });
 
-      it('calls setState once', function() {
-        assert.equal(setStateSpy.calledOnce, true);
+      it('calls setState again', function() {
+        assert.equal(setStateSpy.callCount, 2);
       });
 
-      it('does not call createEventListener for the model', function() {
-        assert.equal(createListenerSpy.callCount, 0);
+      it('does not call createEventListener again for the model', function() {
+        assert.equal(createListenerSpy.callCount, 1);
       });
 
       it('calls removeEventListener once for the model', function() {
-        assert.equal(removeListenerSpy.calledOnce, true);
+        assert.equal(removeListenerSpy.callCount, 1);
       });
     });
   });

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -633,9 +633,10 @@ describe('connectBackboneToReact', function() {
 
     it('calls createEventListener once for the model', function() {
       assert.equal(createListenerSpy.callCount, 1);
+      assert.equal(createListenerSpy.firstCall.args[0], 'decorator');
     });
 
-    it('does not call removeEventListener for the model', function() {
+    it('does not call removeEventListener', function() {
       assert.equal(removeListenerSpy.callCount, 0);
     });
 
@@ -654,12 +655,13 @@ describe('connectBackboneToReact', function() {
         assert.equal(setStateSpy.callCount, 2);
       });
 
-      it('does not call createEventListener again for the model', function() {
+      it('does not call createEventListener again', function() {
         assert.equal(createListenerSpy.callCount, 1);
       });
 
       it('calls removeEventListener once for the model', function() {
         assert.equal(removeListenerSpy.callCount, 1);
+        assert.equal(removeListenerSpy.firstCall.args[0], 'decorator');
       });
     });
   });

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -631,7 +631,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(setStateSpy.callCount, 1);
     });
 
-    it('calls createEventListener once for the model', function() {
+    it('calls createEventListener once due to decoratorUserModel being added as a model', function() {
       assert.equal(createListenerSpy.callCount, 1);
       assert.equal(createListenerSpy.firstCall.args[0], 'decorator');
     });
@@ -659,7 +659,7 @@ describe('connectBackboneToReact', function() {
         assert.equal(createListenerSpy.callCount, 1);
       });
 
-      it('calls removeEventListener once for the model', function() {
+      it('calls removeEventListener once for decoratorUserModel', function() {
         assert.equal(removeListenerSpy.callCount, 1);
         assert.equal(removeListenerSpy.firstCall.args[0], 'decorator');
       });


### PR DESCRIPTION
There are some cases where a Backbone model passed through CBR
might become undefined. (Consider the case where a view relies on
a secondary model as a "decorator", and the use of that "decorator"
model is toggled on or off.) Today, when a model becomes undefined,
CBR throws a TypeError in componentWillReceiveProps:

Uncaught TypeError: Cannot read property 'on' of undefined

This commit adds a check for null or undefined models before trying
to set event listeners in componentWillReceiveProps.