### PR TITLE
Avoid strict mode deprecation errors

### DIFF
--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -2,8 +2,8 @@ const { Children, createElement } = require('react');
 const PropTypes = require('prop-types');
 const { Provider } = require('./context');
 
-function BackboneProvider() {
-  return createElement(Provider, { value: this.props.models }, Children.only(this.props.children));
+function BackboneProvider(props) {
+  return createElement(Provider, { value: props.models }, Children.only(props.children));
 }
 
 BackboneProvider.propTypes = {

--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -1,12 +1,10 @@
 const React = require('react');
-const { Component, Children, createElement } = React;
+const { Children, createElement } = React;
 const PropTypes = require('prop-types');
 const { Provider } = require('./context');
 
-class BackboneProvider extends Component {
-  render() {
-    return createElement(Provider, { value: this.props.models }, Children.only(this.props.children));
-  }
+function BackboneProvider() {
+  return createElement(Provider, { value: this.props.models }, Children.only(this.props.children));
 }
 
 BackboneProvider.propTypes = {

--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -1,5 +1,7 @@
-const { Component, Children } = require('react');
+const React = require('react');
+const { Component, Children, createElement } = React;
 const PropTypes = require('prop-types');
+const { Provider } = require('./context');
 
 class BackboneProvider extends Component {
   getChildContext() {
@@ -9,7 +11,7 @@ class BackboneProvider extends Component {
   }
 
   render() {
-    return Children.only(this.props.children);
+    return createElement(Provider, { value: this.props.models }, Children.only(this.props.children));
   }
 }
 

--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -1,5 +1,4 @@
-const React = require('react');
-const { Children, createElement } = React;
+const { Children, createElement } = require('react');
 const PropTypes = require('prop-types');
 const { Provider } = require('./context');
 

--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -4,12 +4,6 @@ const PropTypes = require('prop-types');
 const { Provider } = require('./context');
 
 class BackboneProvider extends Component {
-  getChildContext() {
-    return {
-      models: this.props.models,
-    };
-  }
-
   render() {
     return createElement(Provider, { value: this.props.models }, Children.only(this.props.children));
   }
@@ -18,9 +12,6 @@ class BackboneProvider extends Component {
 BackboneProvider.propTypes = {
   models: PropTypes.object,
   children: PropTypes.element.isRequired,
-};
-BackboneProvider.childContextTypes = {
-  models: PropTypes.object,
 };
 BackboneProvider.displayName = 'BackboneProvider';
 

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -71,10 +71,6 @@ module.exports = function connectBackboneToReact(
       constructor(props, context) {
         super(props, context);
 
-        this.setModels(props, context);
-
-        this.state = mapModelsToProps(this.models, this.props);
-
         this.createNewProps = this.createNewProps.bind(this);
         this.setWrappedInstance = this.setWrappedInstance.bind(this);
 
@@ -86,20 +82,24 @@ module.exports = function connectBackboneToReact(
         this.createEventListeners();
       }
 
-      setModels(props, contextModels) {
-        const models = Object.assign({}, contextModels, props.models);
+      getModels() {
+        const models = Object.assign({}, this.context, this.props.models);
         validateModelTypes(models);
-        this.models = models;
+        return models;
       }
 
       createEventListeners() {
-        Object.keys(this.models).forEach(mapKey => {
-          const model = this.models[mapKey];
+        const models = this.getModels();
+        Object.keys(models).forEach(mapKey => {
+          const model = models[mapKey];
           // Do not attempt to create event listeners on an undefined model.
           if (!model) return;
 
           this.createEventListener(mapKey, model);
         });
+
+        // Store a reference to the models with event listeners for the next update.
+        this.prevModels = models;
       }
 
       createEventListener(modelName, model) {
@@ -122,8 +122,7 @@ module.exports = function connectBackboneToReact(
         if (this.hasBeenUnmounted) {
           return;
         }
-
-        this.setState(mapModelsToProps(this.models, this.props));
+        this.forceUpdate();
       }
 
       setWrappedInstance(ref) {
@@ -138,37 +137,32 @@ module.exports = function connectBackboneToReact(
         return this.wrappedInstance;
       }
 
-      UNSAFE_componentWillReceiveProps(nextProps, nextContext) { // eslint-disable-line camelcase
-        this.setModels(nextProps, nextContext);
-        this.createNewProps();
+      componentDidUpdate() {
+        // add and remove listeners
+        const models = this.getModels();
+        const prevModels = this.prevModels;
 
         // Bind event listeners for each model that changed.
-        Object.keys(this.models).forEach(mapKey => {
-          const model = this.models[mapKey];
-
-          // Retrieve old versions of the model from props and context for comparison.
-          const propsModel = this.props.models ? this.props.models[mapKey] : undefined;
-          const contextModel = this.context ? this.context[mapKey] : undefined;
+        Object.keys(Object.assign({}, models, prevModels)).forEach(mapKey => {
+          const model = models[mapKey];
+          const prevModel = prevModels[mapKey];
 
           // Do not attempt to create event listeners on an undefined model.
           if (!model) {
             // Instead, if it was previously defined, remove the old listeners.
-            if (propsModel) {
-              this.removeEventListener(mapKey, propsModel);
-              // If a model with the matching mapKey exists in both props and context,
-              // we only remove listeners from the one in props. We do this because
-              // only the one in props is actually used in this.models, per the
-              // Object.assign in setModel.
-            } else if (contextModel) {
-              this.removeEventListener(mapKey, contextModel);
+            if (prevModel) {
+              this.removeEventListener(mapKey, prevModel);
             }
             return;
           }
 
-          if ((propsModel === model) || (contextModel === model)) return; // Did not change.
+          if (prevModel === model) return; // Did not change.
 
           this.createEventListener(mapKey, model);
         });
+
+        // Store a reference to the models with event listeners for the next update.
+        this.prevModels = models;
       }
 
       componentWillUnmount() {
@@ -176,8 +170,8 @@ module.exports = function connectBackboneToReact(
           this.createNewProps.cancel();
         }
 
-        Object.keys(this.models).forEach(mapKey => {
-          const model = this.models[mapKey];
+        Object.keys(this.prevModels).forEach(mapKey => {
+          const model = this.prevModels[mapKey];
           // Do not attempt to remove event listeners on an undefined model.
           if (!model) return;
           this.removeEventListener(mapKey, model);
@@ -189,7 +183,7 @@ module.exports = function connectBackboneToReact(
       render() {
         const wrappedProps = Object.assign(
           {},
-          this.state,
+          mapModelsToProps(this.getModels(), this.props),
           this.props
         );
 

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -2,6 +2,7 @@ const hoistStatics = require('hoist-non-react-statics');
 const { Component, createElement } = require('react');
 const PropTypes = require('prop-types');
 const debounceFn = require('lodash.debounce');
+const BackboneToReactContext = require('./context');
 
 function getDisplayName(name) {
   return `connectBackboneToReact(${name})`;
@@ -85,8 +86,8 @@ module.exports = function connectBackboneToReact(
         this.createEventListeners();
       }
 
-      setModels(props, context) {
-        const models = Object.assign({}, context.models, props.models);
+      setModels(props, contextModels) {
+        const models = Object.assign({}, contextModels, props.models);
         validateModelTypes(models);
         this.models = models;
       }
@@ -147,7 +148,7 @@ module.exports = function connectBackboneToReact(
 
           // Retrieve old versions of the model from props and context for comparison.
           const propsModel = this.props.models ? this.props.models[mapKey] : undefined;
-          const contextModel = this.context.models ? this.context.models[mapKey] : undefined;
+          const contextModel = this.context ? this.context[mapKey] : undefined;
 
           // Do not attempt to create event listeners on an undefined model.
           if (!model) {
@@ -210,7 +211,7 @@ module.exports = function connectBackboneToReact(
     ConnectBackboneToReact.WrappedComponent = WrappedComponent;
     ConnectBackboneToReact.displayName = displayName;
     ConnectBackboneToReact.propTypes = propTypes;
-    ConnectBackboneToReact.contextTypes = propTypes;
+    ConnectBackboneToReact.contextType = BackboneToReactContext;
 
     return hoistStatics(ConnectBackboneToReact, WrappedComponent);
   };

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -71,6 +71,8 @@ module.exports = function connectBackboneToReact(
       constructor(props, context) {
         super(props, context);
 
+        this.componentIsMounted = false;
+
         this.createNewProps = this.createNewProps.bind(this);
         this.setWrappedInstance = this.setWrappedInstance.bind(this);
 
@@ -119,7 +121,8 @@ module.exports = function connectBackboneToReact(
         // The only case where this flag is encountered is when this component
         // is unmounted within an event handler but the 'all' event is still triggered.
         // It is covered in a test case.
-        if (this.hasBeenUnmounted) {
+        // Also bails if we haven't yet mounted, to avoid warnings in strict mode.
+        if (!this.componentIsMounted) {
           return;
         }
         this.forceUpdate();
@@ -135,6 +138,10 @@ module.exports = function connectBackboneToReact(
         }
 
         return this.wrappedInstance;
+      }
+
+      componentDidMount() {
+        this.componentIsMounted = true;
       }
 
       componentDidUpdate() {
@@ -177,7 +184,7 @@ module.exports = function connectBackboneToReact(
           this.removeEventListener(mapKey, model);
         });
 
-        this.hasBeenUnmounted = true;
+        this.componentIsMounted = false;
       }
 
       render() {

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,0 +1,3 @@
+const { createContext } = require('react');
+
+module.exports = createContext();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.3.0-0"
+    "react": "^16.6.0-0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -86,10 +86,10 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when mounted', function() {
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
@@ -120,7 +120,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(wrapper.find(TestComponent).prop('name'), newName);
 
-      assert.equal(setStateSpy.callCount, 4);
+      assert.equal(forceUpdateSpy.callCount, 4);
     });
 
     it('updates properties when model and collections change', function() {
@@ -131,7 +131,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(wrapper.find(TestComponent).prop('name'), newName);
 
-      assert.equal(setStateSpy.callCount, 4);
+      assert.equal(forceUpdateSpy.callCount, 4);
     });
 
     it('creates listeners for every model', function() {
@@ -158,13 +158,13 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when mounted with debounce set to true', function() {
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
         { debounce: true }
       )(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
@@ -184,7 +184,7 @@ describe('connectBackboneToReact', function() {
         assert.equal(userModel.get('name'), newName);
         assert.equal(wrapper.find(TestComponent).prop('name'), newName);
 
-        assert.equal(setStateSpy.callCount, 1);
+        assert.equal(forceUpdateSpy.callCount, 1);
 
         done();
       }, 0);
@@ -199,7 +199,7 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('name'), newName);
       assert.equal(stub.props().name, 'Harry');
 
-      assert.equal(setStateSpy.callCount, 0);
+      assert.equal(forceUpdateSpy.callCount, 0);
     });
   });
 
@@ -217,7 +217,7 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when mounted with custom event names', function() {
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
@@ -228,7 +228,7 @@ describe('connectBackboneToReact', function() {
           },
         }
       )(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
@@ -259,7 +259,7 @@ describe('connectBackboneToReact', function() {
     it('rerenders when tracked property changes', function() {
       const newName = 'Banana';
       userModel.set('name', newName);
-      assert.equal(setStateSpy.callCount, 1);
+      assert.equal(forceUpdateSpy.callCount, 1);
     });
 
     it('does not update properties when non tracked property changes', function() {
@@ -269,13 +269,13 @@ describe('connectBackboneToReact', function() {
       assert.equal(userModel.get('age'), newAge);
       assert.equal(stub.props().age, 25);
 
-      assert.equal(setStateSpy.callCount, 0);
+      assert.equal(forceUpdateSpy.callCount, 0);
     });
 
     it('does not rerender when non tracked property changes', function() {
       const newAge = 99;
       userModel.set('age', newAge);
-      assert.equal(setStateSpy.callCount, 0);
+      assert.equal(forceUpdateSpy.callCount, 0);
     });
   });
 
@@ -336,10 +336,10 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when only given modelsMap object', function() {
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact()(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
@@ -370,12 +370,12 @@ describe('connectBackboneToReact', function() {
 
       assert.equal(wrapper.find(TestComponent).getElement().props.user.name, 'Banana');
 
-      assert.equal(setStateSpy.callCount, 4);
+      assert.equal(forceUpdateSpy.callCount, 4);
     });
   });
 
   describe('when given modelsMap and event options', function() {
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         null,
@@ -386,7 +386,7 @@ describe('connectBackboneToReact', function() {
           },
         }
       )(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
       stub = wrapper.find(TestComponent);
@@ -418,13 +418,13 @@ describe('connectBackboneToReact', function() {
 
       assert.equal(wrapper.find(TestComponent).getElement().props.user.name, 'Banana');
 
-      assert.equal(setStateSpy.callCount, 1);
+      assert.equal(forceUpdateSpy.callCount, 1);
     });
   });
 
   describe('when modelTypes are defined on the options object', function() {
     describe('and the model given is not an instance of required modelType', function() {
-      let setStateSpy;
+      let forceUpdateSpy;
       let errObj;
 
       beforeEach(function() {
@@ -436,7 +436,7 @@ describe('connectBackboneToReact', function() {
             },
           }
         )(TestComponent);
-        setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+        forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
         settingsModel = new SettingsModel();
         modelsMap = {
@@ -451,7 +451,7 @@ describe('connectBackboneToReact', function() {
       });
 
       it('does not render', function() {
-        assert.equal(setStateSpy.callCount, 0);
+        assert.equal(forceUpdateSpy.callCount, 0);
       });
 
       it('throws an error', function() {
@@ -505,10 +505,10 @@ describe('connectBackboneToReact', function() {
 
     let a;
     let b;
-    let setStateSpy;
+    let forceUpdateSpy;
     beforeEach(function() {
       let ConnectedTest = connectBackboneToReact(mapWithProps)(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
       a = new UserModel({
         name: 'A',
         age: '10',
@@ -536,8 +536,8 @@ describe('connectBackboneToReact', function() {
       assert.equal(stub.find('.name').text(), a.get('name'));
       assert.equal(stub.find('.age').text(), a.get('age'));
 
-      // Using props should not increase the number of times setState is called.
-      assert.equal(setStateSpy.calledOnce, false);
+      // Using props should not increase the number of times forceUpdate is called.
+      assert.equal(forceUpdateSpy.calledOnce, false);
     });
 
     it('update the models based on new props', function() {
@@ -550,16 +550,14 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when passed props change', function() {
-    let setStateSpy;
     let newName;
     let newAge;
     let newUserModel;
 
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
 
-      wrapper = mount(<ConnectedTest models={modelsMap} />);
+      wrapper = mount(React.createElement(ConnectedTest, { models: modelsMap }));
       stub = wrapper.find(TestComponent);
 
       newName = 'Robert';
@@ -582,10 +580,6 @@ describe('connectBackboneToReact', function() {
       wrapper.unmount();
     });
 
-    it('calls setState once', function() {
-      assert.equal(setStateSpy.calledOnce, true);
-    });
-
     it('renders the new props', function() {
       assert.equal(stub.find('.name').text(), newName);
       assert.equal(stub.find('.age').text(), newAge);
@@ -602,7 +596,6 @@ describe('connectBackboneToReact', function() {
 
   describe('when passed props change to include', function() {
     let ConnectedTest;
-    let setStateSpy;
     let createListenerSpy;
     let removeListenerSpy;
 
@@ -610,7 +603,6 @@ describe('connectBackboneToReact', function() {
       ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
       wrapper = mount(<ConnectedTest models={modelsMap} />);
 
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
       createListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
       removeListenerSpy = sandbox.spy(ConnectedTest.prototype, 'removeEventListener');
 
@@ -633,10 +625,6 @@ describe('connectBackboneToReact', function() {
       wrapper.unmount();
     });
 
-    it('calls setState once', function() {
-      assert.equal(setStateSpy.callCount, 1);
-    });
-
     it('calls createEventListener once due to decoratorUserModel being added as a model', function() {
       assert.equal(createListenerSpy.callCount, 1);
       assert.equal(createListenerSpy.firstCall.args[0], 'decorator');
@@ -655,10 +643,6 @@ describe('connectBackboneToReact', function() {
         };
 
         wrapper.setProps({ models: newModelsMap });
-      });
-
-      it('calls setState again', function() {
-        assert.equal(setStateSpy.callCount, 2);
       });
 
       it('does not call createEventListener again', function() {
@@ -683,12 +667,12 @@ describe('connectBackboneToReact', function() {
     // the "allEvents" value is stale.
 
     const arbitraryEvent = 'arbitraryEvent';
-    let setStateSpy;
+    let forceUpdateSpy;
 
     beforeEach(function() {
       // eslint-disable-next-line no-unused-vars
       const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
-      setStateSpy = sandbox.spy(ConnectedTest.prototype, 'setState');
+      forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);
 
@@ -698,15 +682,15 @@ describe('connectBackboneToReact', function() {
         wrapper.unmount();
 
         // But because we're subscribed to the "all" event it will still trigger that handler,
-        // calling setState when it shouldn't.
+        // calling forceUpdate when it shouldn't.
       });
 
       // Trigger the event.
       userModel.trigger(arbitraryEvent);
     });
 
-    it('does not call setState', function() {
-      assert.equal(setStateSpy.called, false);
+    it('does not call forceUpdate', function() {
+      assert.equal(forceUpdateSpy.called, false);
     });
   });
 


### PR DESCRIPTION
This switches to using the new context API (along with a `peerDependency` bump to React 16.6 in order to get support for the `contextType` field), and removes any use of deprecated methods. While removing `componentWillReceiveProps` calls, I eventually just had it generate the props to pass down during `render` instead of storing them in `state` as an intermediary, and used `forceUpdate` instead of `setState` calls when the backbone model had a change event. There were a few tests that were spying directly on the `setState` call, so I had to tweak those, but otherwise all of the functionality seems to be intact. The one thing that I'm not sure about is if this is going to cause any performance regressions, but it felt like it was ready for an initial review, at least.

Resolves #23 