### PR TITLE
Add useBackboneContext hook for use by functional components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-<a name="3.2.0"></a>
-# [3.2.0](https://github.com/mongodb-js/connect-backbone-to-react/compare/v3.0.0...v3.2.0) (2020-03-06)
-
 
 
 <a name="3.1.0"></a>
 # [3.1.0](https://github.com/mongodb-js/connect-backbone-to-react/compare/v3.0.0...v3.1.0) (2020-03-06)
+
+* Adds the useBackboneContext hook, which can be called to return the models and collections converted to JSON for usage in functional components
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.2.0"></a>
+# [3.2.0](https://github.com/mongodb-js/connect-backbone-to-react/compare/v3.0.0...v3.2.0) (2020-03-06)
+
+
+
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/mongodb-js/connect-backbone-to-react/compare/v3.0.0...v3.1.0) (2020-03-06)
+
+
+
 <a name="3.0.0"></a>
 # [3.0.0](https://github.com/mongodb-js/connect-backbone-to-react/compare/v2.0.0...v3.0.0) (2020-01-30)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,43 @@ ReactDOM.render(
 );
 ```
 
+### useBackboneContext
+When used in a descendent of the Backbone Provider, the `useBackboneContext` hook allows access to values of all models and collections on the Provider's context, converted to JSON. 
+
+```javascript
+const { useBackboneContext } = require('connect-backbone-to-react');
+
+const modelsMap = {
+  user: userInstance,
+  allUsers: userCollection,
+},
+
+const ComponentUsingHooks = () => {
+  const { user, allUsers } = useBackboneContext();
+  render (
+    <>
+      <div>
+        <h2>Primary User</h2>
+        <ul>
+          <li>{user.name}</li>
+        </ul>
+      </div>
+
+      <div>
+      <h2>Secondary Users</h2>
+      <ul>
+        {allUsers.map(user => (
+          <li key={user.name}>
+            {user.name}
+          </li>
+        ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+```
+
 ## Rendering React Within Backbone.View
 
 This library's focus is on sharing Backbone.Models with React Components. It is not concerned with how to render React Components within Backbone.Views. [The React docs provide a possible implementation for this interopt.](https://reactjs.org/docs/integrating-with-other-libraries.html#embedding-react-in-a-backbone-view)

--- a/lib/backbone-provider.js
+++ b/lib/backbone-provider.js
@@ -1,9 +1,11 @@
-const { Children, createElement } = require('react');
+const {Children, createElement} = require('react');
 const PropTypes = require('prop-types');
-const { Provider } = require('./context');
+const {Provider} = require('./context');
 
 function BackboneProvider(props) {
-  return createElement(Provider, { value: props.models }, Children.only(props.children));
+  return createElement(Provider, {
+    value: props.models,
+  }, Children.only(props.children));
 }
 
 BackboneProvider.propTypes = {

--- a/lib/connect-backbone-to-react.js
+++ b/lib/connect-backbone-to-react.js
@@ -1,5 +1,5 @@
 const hoistStatics = require('hoist-non-react-statics');
-const { Component, createElement } = require('react');
+const {Component, createElement} = require('react');
 const PropTypes = require('prop-types');
 const debounceFn = require('lodash.debounce');
 const BackboneToReactContext = require('./context');
@@ -11,7 +11,9 @@ function getDisplayName(name) {
 function defaultMapModelsToProps(models) {
   return Object.keys(models).reduce((acc, modelKey) => {
     const model = models[modelKey];
-    if (!model) return;
+    if (!model) {
+      return;
+    }
 
     acc[modelKey] = model.toJSON();
     return acc;
@@ -19,19 +21,13 @@ function defaultMapModelsToProps(models) {
 }
 
 module.exports = function connectBackboneToReact(
-  mapModelsToProps,
-  options = {}
+  mapModelsToProps, options = {}
 ) {
   if (typeof mapModelsToProps !== 'function') {
     mapModelsToProps = defaultMapModelsToProps;
   }
 
-  const {
-    debounce = false,
-    events = {},
-    modelTypes = {},
-    withRef = false,
-  } = options;
+  const {debounce = false, events = {}, modelTypes = {}, withRef = false} = options;
 
   function getEventNames(modelName) {
     let eventNames = events[modelName];
@@ -95,7 +91,9 @@ module.exports = function connectBackboneToReact(
         Object.keys(models).forEach(mapKey => {
           const model = models[mapKey];
           // Do not attempt to create event listeners on an undefined model.
-          if (!model) return;
+          if (!model) {
+            return;
+          }
 
           this.createEventListener(mapKey, model);
         });
@@ -163,7 +161,9 @@ module.exports = function connectBackboneToReact(
             return;
           }
 
-          if (prevModel === model) return; // Did not change.
+          if (prevModel === model) {
+            return;
+          } // Did not change.
 
           this.createEventListener(mapKey, model);
         });
@@ -180,7 +180,9 @@ module.exports = function connectBackboneToReact(
         Object.keys(this.prevModels).forEach(mapKey => {
           const model = this.prevModels[mapKey];
           // Do not attempt to remove event listeners on an undefined model.
-          if (!model) return;
+          if (!model) {
+            return;
+          }
           this.removeEventListener(mapKey, model);
         });
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,3 +1,3 @@
-const { createContext } = require('react');
+const {createContext} = require('react');
 
 module.exports = createContext();

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 const connectBackboneToReact = require('./connect-backbone-to-react');
 const BackboneProvider = require('./backbone-provider');
+const useBackboneContext = require('./useBackboneContext');
 
 exports.connectBackboneToReact = connectBackboneToReact;
 exports.BackboneProvider = BackboneProvider;
+exports.useBackboneContext = useBackboneContext;

--- a/lib/useBackboneContext.js
+++ b/lib/useBackboneContext.js
@@ -1,0 +1,18 @@
+const {useContext} = require('react');
+const Context = require('./context');
+
+function useBackboneContext() {
+  const backboneContext = useContext(Context);
+
+  if (backboneContext === undefined) {
+    throw new Error('useBackboneContext must be called within a provider');
+  }
+
+  return Object.keys(backboneContext)
+    .reduce((jsonContext, key) => {
+      jsonContext[key] = backboneContext[key].toJSON();
+      return jsonContext;
+    }, {});
+}
+
+module.exports = useBackboneContext;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-backbone-to-react",
-  "version": "1.6.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -103,7 +103,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2815,8 +2814,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
@@ -2882,8 +2880,7 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
@@ -2900,7 +2897,6 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
-          "optional": true,
           "requires": {
             "inherits": "~2.0.0"
           }
@@ -2910,7 +2906,6 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.x.x"
           }
@@ -2920,7 +2915,6 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
           "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
@@ -2930,8 +2924,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
           "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.11.0",
@@ -2958,15 +2951,13 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -2985,22 +2976,19 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -3052,8 +3040,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
           "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -3090,8 +3077,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
           "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -3116,15 +3102,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fstream": {
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
           "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
           "dev": true,
-          "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "inherits": "~2.0.0",
@@ -3202,7 +3186,6 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -3216,8 +3199,7 @@
           "version": "4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "graceful-readlink": {
           "version": "1.0.1",
@@ -3273,8 +3255,7 @@
           "version": "2.16.3",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
           "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
@@ -3293,7 +3274,6 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -3303,8 +3283,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.4",
@@ -3318,7 +3297,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3354,8 +3332,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -3418,15 +3395,13 @@
           "version": "1.26.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
           "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.14",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mime-db": "~1.26.0"
           }
@@ -3436,7 +3411,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.0.0"
           }
@@ -3445,15 +3419,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3510,8 +3482,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -3532,7 +3503,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3541,8 +3511,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
@@ -3565,8 +3534,7 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "punycode": {
           "version": "1.4.1",
@@ -3654,7 +3622,6 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
           "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.0.5"
           }
@@ -3722,7 +3689,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3733,8 +3699,7 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -3748,7 +3713,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3772,7 +3736,6 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -3859,8 +3822,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "uuid": {
           "version": "3.0.1",
@@ -3893,8 +3855,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "xtend": {
           "version": "4.0.1",
@@ -4081,7 +4042,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -4410,8 +4370,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
       "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4462,8 +4421,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -4488,7 +4446,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -4510,7 +4467,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -4562,8 +4518,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-property": {
       "version": "1.0.2",
@@ -4954,7 +4909,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.0.2"
       }
@@ -5247,8 +5201,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -6387,8 +6340,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-backbone-to-react",
   "description": "Connect Backbone Models and Collections to React.",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "scripts": {
     "fmt": "mongodb-js-fmt",
     "check": "mongodb-js-precommit",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-backbone-to-react",
   "description": "Connect Backbone Models and Collections to React.",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "scripts": {
     "fmt": "mongodb-js-fmt",
     "check": "mongodb-js-precommit",

--- a/test/backbone-provider.test.js
+++ b/test/backbone-provider.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
-const { mount } = require('enzyme');
+const {mount} = require('enzyme');
 const sinon = require('sinon');
 const React = require('react');
-const { Component } = React;
-const { Model, Collection } = require('backbone');
+const {Component} = React;
+const {Model, Collection} = require('backbone');
 const BackboneProvider = require('../lib/backbone-provider'); // eslint-disable-line no-unused-vars
 const connectBackboneToReact = require('../lib/connect-backbone-to-react');
 
@@ -100,8 +100,14 @@ describe('BackboneProvider', function() {
     });
 
     it('should handle updates to passed props', function() {
-      const model = new Model({ name: 'Jill' });
-      wrapper.setProps({ models: { user: model }});
+      const model = new Model({
+        name: 'Jill',
+      });
+      wrapper.setProps({
+        models: {
+          user: model,
+        },
+      });
 
       assert(wrapper.find('.name').everyWhere(n => n.text() === 'Jill'));
     });
@@ -129,7 +135,9 @@ describe('BackboneProvider', function() {
       const settingsModel = new Model({
         color: 'purple',
       });
-      const propsModelsMap = { settings: settingsModel };
+      const propsModelsMap = {
+        settings: settingsModel,
+      };
 
       wrapper = mount(
         <BackboneProvider models={modelsMap}>
@@ -161,7 +169,9 @@ describe('BackboneProvider', function() {
       class PassingParent extends Component {
         render() {
           // We're using the same key (`user`) as the modelsMap passed via context.
-          const propsModelsMap = { user: otherUserModel };
+          const propsModelsMap = {
+            user: otherUserModel,
+          };
 
           return (
             <div>

--- a/test/connect-backbone-to-react.test.js
+++ b/test/connect-backbone-to-react.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
-const { mount } = require('enzyme');
+const {mount} = require('enzyme');
 const sinon = require('sinon');
 const React = require('react');
-const { Component } = React;
-const { Model, Collection } = require('backbone');
+const {Component} = React;
+const {Model, Collection} = require('backbone');
 const connectBackboneToReact = require('../lib/connect-backbone-to-react');
 
 describe('connectBackboneToReact', function() {
@@ -68,7 +68,7 @@ describe('connectBackboneToReact', function() {
       coll: userCollection,
     };
 
-    mapModelsToProps = function({ user, coll }) {
+    mapModelsToProps = function({user, coll}) {
       return {
         name: user.get('name'),
         age: user.get('age'),
@@ -96,7 +96,9 @@ describe('connectBackboneToReact', function() {
     });
 
     afterEach(function() {
-      if (wrapper.exists()) wrapper.unmount();
+      if (wrapper.exists()) {
+        wrapper.unmount();
+      }
     });
 
     it('passes mapped models and collections as properties to wrapped component', function() {
@@ -104,7 +106,11 @@ describe('connectBackboneToReact', function() {
       assert.equal(stub.props().age, 25);
       assert.equal(stub.props().hungry, true);
       assert.equal(typeof stub.props().changeName, 'function');
-      assert.deepEqual(stub.props().users, [ { name: 'Harry', age: 25, hungry: true } ]);
+      assert.deepEqual(stub.props().users, [{
+        name: 'Harry',
+        age: 25,
+        hungry: true,
+      }]);
     });
 
     it('renders wrapped component', function() {
@@ -162,7 +168,9 @@ describe('connectBackboneToReact', function() {
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
-        { debounce: true }
+        {
+          debounce: true,
+        }
       )(TestComponent);
       forceUpdateSpy = sandbox.spy(ConnectedTest.prototype, 'forceUpdate');
 
@@ -171,7 +179,9 @@ describe('connectBackboneToReact', function() {
     });
 
     afterEach(function() {
-      if (wrapper.exists()) wrapper.unmount();
+      if (wrapper.exists()) {
+        wrapper.unmount();
+      }
     });
 
     it('updates properties when model and collections change', function(done) {
@@ -211,7 +221,9 @@ describe('connectBackboneToReact', function() {
     it('the default should mount and unmount the component successfully', function() {
       const ConnectedTest = connectBackboneToReact()(TestComponent);
       const eventListenerSpy = sandbox.spy(ConnectedTest.prototype, 'createEventListener');
-      wrapper = mount(<ConnectedTest models={{user: null}} />);
+      wrapper = mount(<ConnectedTest models={{
+        user: null,
+      }} />);
       assert.equal(eventListenerSpy.callCount, 0);
     });
   });
@@ -493,9 +505,13 @@ describe('connectBackboneToReact', function() {
   });
 
   describe('when using props in mapModelsToProps', function() {
-    function mapWithProps({ coll }, { name }) {
-      if (!name) return {};
-      const user = coll.findWhere({ name });
+    function mapWithProps({coll}, {name}) {
+      if (!name) {
+        return {};
+      }
+      const user = coll.findWhere({
+        name,
+      });
       return {
         name: user.get('name'),
         age: user.get('age'),
@@ -541,7 +557,9 @@ describe('connectBackboneToReact', function() {
     });
 
     it('update the models based on new props', function() {
-      wrapper.setProps({ name: 'B'});
+      wrapper.setProps({
+        name: 'B',
+      });
       b.set('hungry', true);
 
       assert.equal(stub.find('.name').text(), b.get('name'));
@@ -557,7 +575,9 @@ describe('connectBackboneToReact', function() {
     beforeEach(function() {
       const ConnectedTest = connectBackboneToReact(mapModelsToProps)(TestComponent);
 
-      wrapper = mount(React.createElement(ConnectedTest, { models: modelsMap }));
+      wrapper = mount(React.createElement(ConnectedTest, {
+        models: modelsMap,
+      }));
       stub = wrapper.find(TestComponent);
 
       newName = 'Robert';
@@ -573,7 +593,9 @@ describe('connectBackboneToReact', function() {
         coll: userCollection,
       };
 
-      wrapper.setProps({ models: newModelsMap });
+      wrapper.setProps({
+        models: newModelsMap,
+      });
     });
 
     afterEach(function() {
@@ -618,7 +640,9 @@ describe('connectBackboneToReact', function() {
         decorator: decoratorUserModel,
       };
 
-      wrapper.setProps({ models: initialModelsMap });
+      wrapper.setProps({
+        models: initialModelsMap,
+      });
     });
 
     afterEach(function() {
@@ -642,7 +666,9 @@ describe('connectBackboneToReact', function() {
           decorator: undefined,
         };
 
-        wrapper.setProps({ models: newModelsMap });
+        wrapper.setProps({
+          models: newModelsMap,
+        });
       });
 
       it('does not call createEventListener again', function() {
@@ -681,8 +707,8 @@ describe('connectBackboneToReact', function() {
         // When called it unmounts an component.
         wrapper.unmount();
 
-        // But because we're subscribed to the "all" event it will still trigger that handler,
-        // calling forceUpdate when it shouldn't.
+      // But because we're subscribed to the "all" event it will still trigger that handler,
+      // calling forceUpdate when it shouldn't.
       });
 
       // Trigger the event.
@@ -719,7 +745,9 @@ describe('connectBackboneToReact', function() {
       // eslint-disable-next-line no-unused-vars
       const ConnectedTest = connectBackboneToReact(
         mapModelsToProps,
-        { withRef: true }
+        {
+          withRef: true,
+        }
       )(TestComponent);
 
       wrapper = mount(<ConnectedTest models={modelsMap} />);

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,7 +1,9 @@
 require('babel-register');
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
-Enzyme.configure({ adapter: new Adapter() });
+Enzyme.configure({
+  adapter: new Adapter(),
+});
 const jsdom = require('jsdom').jsdom;
 
 global.document = jsdom('');

--- a/test/useBackboneContext.test.js
+++ b/test/useBackboneContext.test.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+const {mount} = require('enzyme');
+const {Model, Collection} = require('backbone');
+const BackboneProvider = require('../lib/backbone-provider'); // eslint-disable-line no-unused-vars
+const useBackboneContext = require('../lib/useBackboneContext');
+
+describe('useBackboneContext', function() {
+  let wrapper;
+
+  function UnconnectedComponent() { // eslint-disable-line no-unused-vars
+    const context = useBackboneContext();
+    return (
+      <div>
+        <div className="name">
+          {context.user.name}
+        </div>
+      </div>
+    );
+  }
+
+  afterEach(function() {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  describe('when the useBackboneContext hook is used outside of a provider', function() {
+    it('throws a relevant error', function() {
+      const expectedError = {
+        message: 'useBackboneContext must be called within a provider',
+      };
+      assert.throws(() => mount(<UnconnectedComponent/>), expectedError);
+    });
+  });
+
+  describe('when a descendent of the provider uses the useBackboneContext hook', function() {
+    beforeEach(function() {
+      const userModel = new Model({
+        name: 'Harry',
+        age: 25,
+        hungry: true,
+      });
+
+      const userCollection = new Collection([userModel]);
+
+      const modelsMap = {
+        user: userModel,
+        coll: userCollection,
+      };
+
+      wrapper = mount(
+        <BackboneProvider models={modelsMap}>
+          <UnconnectedComponent/>
+        </BackboneProvider>
+      );
+    });
+
+    it('renders the name as Harry ', function() {
+      assert.equal(wrapper.find('.name').length, 1);
+      assert.equal(wrapper.find('.name').text(), 'Harry');
+    });
+
+    describe('when the backbone data is updated', function() {
+      beforeEach(function() {
+        const model = new Model({
+          name: 'Jill',
+        });
+        wrapper.setProps({
+          models: {
+            user: model,
+          },
+        });
+      });
+
+      it('should handle updates to passed props', function() {
+        assert.equal(wrapper.find('.name').text(), 'Jill');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds an additional export, allowing access to a hook that will return the context, with all models or collections converted to JSON using Backbone's native method. If the hook is used and is not the descendent of a Backbone Provider, it will throw an error instead.

I ran the `fmt` script for formatting noted in `package.json`, but it looked like that was out of date as it resulted in a ton of lint failures. As a result there are some whitespace changes in here that snuck in via that script.